### PR TITLE
docs: link to v2 checklist at top of v1

### DIFF
--- a/docs/astro-conversion-checklist.md
+++ b/docs/astro-conversion-checklist.md
@@ -1,5 +1,11 @@
 # Astro conversion checklist — patterns to repeat
 
+> **This is v1 (Astro 5 + yarn, mid-2025). A newer [v2 checklist](https://github.com/ICJIA/icjia-i2i-v2-2024/blob/main/docs/astro-conversion-checklist.md)
+> supersedes it** with updates for Astro 6, pnpm, hash-locked CSP,
+> COOP/CORP, context-scoped headers, audit scripts, and a Sharp-
+> postinstall gotcha. **Use v2 for new projects.** v1 is still valid
+> for existing Astro 5 + yarn projects that aren't upgrading.
+
 Practical patterns that earned their keep on this Vue 2 / Nuxt → Astro 5 +
 Tailwind 4 + Alpine.js rewrite. Copy what fits; nothing here is sacred.
 


### PR DESCRIPTION
## Summary

Adds a callout at the top of `docs/astro-conversion-checklist.md`
pointing readers at the newer v2 checklist that lives in
[icjia-i2i-v2-2024](https://github.com/ICJIA/icjia-i2i-v2-2024/blob/main/docs/astro-conversion-checklist.md).

## Why

The v2 checklist was published 2026-05 with patterns shipped in
i2i's v0.2.0 / v0.2.1 release. Anyone landing on this v1 URL via an
old Slack/email link should see the pointer rather than silently
following stale guidance (yarn instead of pnpm, `'unsafe-inline'`
in CSP, etc.).

## Scope

- One blockquote inserted after the H1 title.
- No content changes anywhere else; v1 remains a valid reference
  for the older Astro 5 + yarn stack.

## Test plan

- [ ] Render the markdown on GitHub and confirm the link to v2 works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Astro conversion checklist with a version notice, identifying the current checklist as v1 (for Astro 5 + yarn projects, mid-2025) and providing a link to the newer v2 guidance (Astro 6, pnpm, CSP and header updates, plus additional resources). Includes guidance on when to use each version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ICJIA/adult-redeploy-client-next/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->